### PR TITLE
Add Score mechanic and methods for updating and getting it. Increment score on token collision.

### DIFF
--- a/Assets/Scripts/Gameplay/PlayerTokenCollision.cs
+++ b/Assets/Scripts/Gameplay/PlayerTokenCollision.cs
@@ -19,6 +19,9 @@ namespace Platformer.Gameplay
         public override void Execute()
         {
             AudioSource.PlayClipAtPoint(token.tokenCollectAudio, token.transform.position);
-        }
+
+            Score.UpdateScore();
+            Debug.Log("Player collected a token! Score: " + Score.GetScore());
+       }
     }
 }

--- a/Assets/Scripts/Mechanics/Score.cs
+++ b/Assets/Scripts/Mechanics/Score.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace Platformer.Mechanics
+{
+    public class Score : MonoBehaviour
+    {
+        private static int score = 0;
+
+        // Change the score by the input amount, or increment it by 1 by default.
+        public static void UpdateScore(int value = 1)
+        {
+            score += value;
+        }
+
+        public static int GetScore()
+        {
+            return score;
+        }
+    }
+}

--- a/Assets/Scripts/Mechanics/Score.cs.meta
+++ b/Assets/Scripts/Mechanics/Score.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56137468efc19468b956e3e57ec1671a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This will currently log the score in the Unity developer console when the player collects a token.