### PR TITLE
Add player method to control eating side effects, apply to enemies & tokens

### DIFF
--- a/Assets/Scripts/Gameplay/PlayerAte.cs
+++ b/Assets/Scripts/Gameplay/PlayerAte.cs
@@ -16,11 +16,11 @@ namespace Platformer.Gameplay
 
         public Vector3 playerScaleChange = new(0.05f, 0.05f, 0.0f);
 
-        // Prey might be an enemy or a token.
-        float preyLevel = 1;
-
         public override void Execute()
         {
+            // Prey might be an enemy or a token.
+            float preyLevel = 1;
+
             if (enemy != null)
             {
                 preyLevel = enemy.GetComponent<SpriteRenderer>().transform.localScale.x;

--- a/Assets/Scripts/Gameplay/PlayerAte.cs
+++ b/Assets/Scripts/Gameplay/PlayerAte.cs
@@ -1,0 +1,38 @@
+﻿using Platformer.Core;
+using Platformer.Mechanics;
+using Platformer.Model;
+using UnityEngine;
+
+namespace Platformer.Gameplay
+{
+    /// <summary>
+    /// Fired when the player eats a token or enemy. Handles related side effects.
+    /// </summary>
+    /// <typeparam name="PlayerAte"></typeparam>
+    public class PlayerAte : Simulation.Event<PlayerAte>
+    {
+        public EnemyController enemy;
+        readonly PlayerController player = Simulation.GetModel<PlatformerModel>().player;
+
+        public Vector3 playerScaleChange = new(0.05f, 0.05f, 0.0f);
+
+        // Prey might be an enemy or a token.
+        float preyLevel = 1;
+
+        public override void Execute()
+        {
+            if (enemy != null)
+            {
+                preyLevel = enemy.GetComponent<SpriteRenderer>().transform.localScale.x;
+            }
+ 
+            Vector3 adjustedPlayerScaleChange = playerScaleChange * preyLevel;
+
+            // Scale up the player sprite after eating.
+            player.GetComponent<SpriteRenderer>().transform.localScale += adjustedPlayerScaleChange;
+
+            // Increment the score after eating.
+            Score.UpdateScore(preyLevel);
+        }
+    }
+}

--- a/Assets/Scripts/Gameplay/PlayerAte.cs.meta
+++ b/Assets/Scripts/Gameplay/PlayerAte.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96bb39c00ed054508a4e1539d54ee4ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/PlayerEnemyCollision.cs
+++ b/Assets/Scripts/Gameplay/PlayerEnemyCollision.cs
@@ -47,7 +47,7 @@ namespace Platformer.Gameplay
             Schedule<EnemyDeath>().enemy = enemy;
             player.Bounce(2);
 
-            player.FattenPlayerAndIncrementScore(2);
+            Schedule<PlayerAte>().enemy = enemy;
         }
     }
 }

--- a/Assets/Scripts/Gameplay/PlayerEnemyCollision.cs
+++ b/Assets/Scripts/Gameplay/PlayerEnemyCollision.cs
@@ -1,6 +1,5 @@
 using Platformer.Core;
 using Platformer.Mechanics;
-using Platformer.Model;
 using UnityEngine;
 using static Platformer.Core.Simulation;
 
@@ -16,51 +15,39 @@ namespace Platformer.Gameplay
         public EnemyController enemy;
         public PlayerController player;
 
-        PlatformerModel model = Simulation.GetModel<PlatformerModel>();
-
         public override void Execute()
         {
-            //is set to true if the player is touching the enemy from the x or y direction
-            var willHurtEnemyY = player.Bounds.center.y >= enemy.Bounds.max.y || player.Bounds.center.y <= enemy.Bounds.max.y;
-            var willHurtEnemyX = player.Bounds.center.x >= enemy.Bounds.max.x || player.Bounds.center.x <= enemy.Bounds.max.x;
+            // True if the player is touching the enemy from the x or y direction
+            bool isCollisionY = player.Bounds.center.y >= enemy.Bounds.max.y || player.Bounds.center.y <= enemy.Bounds.max.y;
+            bool isCollisionX = player.Bounds.center.x >= enemy.Bounds.max.x || player.Bounds.center.x <= enemy.Bounds.max.x;
+
+            bool isCollision = isCollisionX || isCollisionY;
 
             //is set to true if the player is the up to the size we want them to be to eat the enemy
-            var willEatEnemy = enemy.deathPoint <= player.GetComponent<SpriteRenderer>().transform.localScale.x;
+            bool canEatEnemy = enemy.deathPoint <= player.GetComponent<SpriteRenderer>().transform.localScale.x;
 
-            if ((willHurtEnemyY && enemy.yDeath) || (willHurtEnemyX && enemy.xDeath))
+            if (!isCollision)
             {
-                if (willEatEnemy)
-                {
-                    var enemyHealth = enemy.GetComponent<Health>();
-                    if (enemyHealth != null)
-                    {
-                        enemyHealth.Decrement();
-                        if (!enemyHealth.IsAlive)
-                        {
-                            Schedule<EnemyDeath>().enemy = enemy;
-                            player.Bounce(2);
-                        }
-                        else
-                        {
-                            player.Bounce(7);
-                        }
-                    }
-                    else
-                    {
-                        Schedule<EnemyDeath>().enemy = enemy;
-                        player.Bounce(2);
-                    }
-                    player.GetComponent<SpriteRenderer>().transform.localScale += new Vector3(0.2f, 0.2f, 0);
-                }
-                else
-                {
-                    Schedule<PlayerDeath>();
-                }
+                return;
             }
-            else
+
+            if (!canEatEnemy)
             {
                 Schedule<PlayerDeath>();
+                return;
             }
+
+            Health enemyHealth = enemy.GetComponent<Health>();
+            if (enemyHealth != null && enemyHealth.IsAlive)
+            {
+                player.Bounce(7);
+                return;
+            }
+
+            Schedule<EnemyDeath>().enemy = enemy;
+            player.Bounce(2);
+
+            player.FattenPlayerAndIncrementScore(2);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/PlayerTokenCollision.cs
+++ b/Assets/Scripts/Gameplay/PlayerTokenCollision.cs
@@ -16,22 +16,11 @@ namespace Platformer.Gameplay
         public PlayerController player;
         public TokenInstance token;
 
-        PlatformerModel model = Simulation.GetModel<PlatformerModel>();
-
-        // Constants affecting player sprite scaling.
-        private Vector3 playerScaleChange = new(0.02f, 0.02f, 0.0f);
-
         public override void Execute()
         {
-
             AudioSource.PlayClipAtPoint(token.tokenCollectAudio, token.transform.position);
 
-            // Rescale the player sprite when a coin is collected.
-            player.GetComponent<SpriteRenderer>().transform.localScale += playerScaleChange;
-
-            // Increment the score when a coin is collected.
-            Score.UpdateScore();
-            Debug.Log("Player collected a token! Score: " + Score.GetScore());
+            player.FattenPlayerAndIncrementScore(1);
        }
     }
 }

--- a/Assets/Scripts/Gameplay/PlayerTokenCollision.cs
+++ b/Assets/Scripts/Gameplay/PlayerTokenCollision.cs
@@ -20,7 +20,7 @@ namespace Platformer.Gameplay
         {
             AudioSource.PlayClipAtPoint(token.tokenCollectAudio, token.transform.position);
 
-            Schedule<PlayerAte>();
+            Schedule<PlayerAte>().enemy = null;
         }
     }
 }

--- a/Assets/Scripts/Gameplay/PlayerTokenCollision.cs
+++ b/Assets/Scripts/Gameplay/PlayerTokenCollision.cs
@@ -1,7 +1,7 @@
 using Platformer.Core;
 using Platformer.Mechanics;
-using Platformer.Model;
 using UnityEngine;
+using static Platformer.Core.Simulation;
 
 namespace Platformer.Gameplay
 {
@@ -20,7 +20,7 @@ namespace Platformer.Gameplay
         {
             AudioSource.PlayClipAtPoint(token.tokenCollectAudio, token.transform.position);
 
-            player.FattenPlayerAndIncrementScore(1);
-       }
+            Schedule<PlayerAte>();
+        }
     }
 }

--- a/Assets/Scripts/Mechanics/PlayerController.cs
+++ b/Assets/Scripts/Mechanics/PlayerController.cs
@@ -42,9 +42,6 @@ namespace Platformer.Mechanics
 
         public Bounds Bounds => collider2d.bounds;
 
-        // Constants affecting player sprite scaling.
-        private Vector3 playerScaleChange = new(0.02f, 0.02f, 0.0f);
-
         void Awake()
         {
             health = GetComponent<Health>();
@@ -130,16 +127,6 @@ namespace Platformer.Mechanics
             animator.SetFloat("velocityX", Mathf.Abs(velocity.x) / maxSpeed);
 
             targetVelocity = move * maxSpeed;
-        }
-
-        public void FattenPlayerAndIncrementScore(int value = 1)
-        {
-            Vector3 adjustedPlayerScaleChange = playerScaleChange * value;
-
-            spriteRenderer.transform.localScale += adjustedPlayerScaleChange;
-
-            // Increment the score when a coin is collected.
-            Score.UpdateScore(value);
         }
 
         public enum JumpState

--- a/Assets/Scripts/Mechanics/PlayerController.cs
+++ b/Assets/Scripts/Mechanics/PlayerController.cs
@@ -42,6 +42,9 @@ namespace Platformer.Mechanics
 
         public Bounds Bounds => collider2d.bounds;
 
+        // Constants affecting player sprite scaling.
+        private Vector3 playerScaleChange = new(0.02f, 0.02f, 0.0f);
+
         void Awake()
         {
             health = GetComponent<Health>();
@@ -127,6 +130,16 @@ namespace Platformer.Mechanics
             animator.SetFloat("velocityX", Mathf.Abs(velocity.x) / maxSpeed);
 
             targetVelocity = move * maxSpeed;
+        }
+
+        public void FattenPlayerAndIncrementScore(int value = 1)
+        {
+            Vector3 adjustedPlayerScaleChange = playerScaleChange * value;
+
+            spriteRenderer.transform.localScale += adjustedPlayerScaleChange;
+
+            // Increment the score when a coin is collected.
+            Score.UpdateScore(value);
         }
 
         public enum JumpState

--- a/Assets/Scripts/Mechanics/Score.cs
+++ b/Assets/Scripts/Mechanics/Score.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Platformer.Mechanics
@@ -7,9 +8,9 @@ namespace Platformer.Mechanics
         private static int score = 0;
 
         // Change the score by the input amount, or increment it by 1 by default.
-        public static void UpdateScore(int value = 1)
+        public static void UpdateScore(float value = 1)
         {
-            score += value;
+            score += (int) Math.Round(value * 10);
             UI.ScoreUIController.UpdateScoreText();
         }
 


### PR DESCRIPTION
**Testing Instructions**
- Eat a token or enemy. You'll get 10 points and grow slightly.
- Growth will now be related to the x-scale of the object you're eating.