### PR TITLE
Support DANGER from enemies larger than the player

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -182,9 +182,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   path: {fileID: 0}
   ouch: {fileID: 8300000, guid: b7f741588644cd64bbee6387cb54a96d, type: 3}
-  deathPoint: 0
-  xDeath: 1
-  yDeath: 1
 --- !u!82 &5843668731025413174
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Seamount.unity
+++ b/Assets/Scenes/Seamount.unity
@@ -573,6 +573,121 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 24362291}
   m_CullTransparentMesh: 1
+--- !u!1001 &31824186
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 388159188}
+    m_Modifications:
+    - target: {fileID: 772289407653213039, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: path
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1577774018119691272, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 1577774018119691272, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 1.26
+      objectReference: {fileID: 0}
+    - target: {fileID: 1577774018119691272, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1605217082131907960, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: ed1bbb2dccb7a424a9969f916919f446, type: 2}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -30.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 15.48
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1661912868639658944, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
+      propertyPath: m_Name
+      value: LargeCrab
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f158aa2be3df6489185ef721f6fd79c1, type: 3}
+--- !u!4 &31824187 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1658460978237467174, guid: f158aa2be3df6489185ef721f6fd79c1,
+    type: 3}
+  m_PrefabInstance: {fileID: 31824186}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &38594721
 GameObject:
   m_ObjectHideFlags: 0
@@ -2943,7 +3058,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 232630788}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.1106389, y: 1.2646374, z: -9}
+  m_LocalPosition: {x: 2.4013546, y: 1.2646378, z: -9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4153,6 +4268,7 @@ Transform:
   - {fileID: 132154435}
   - {fileID: 1223705729}
   - {fileID: 751610080}
+  - {fileID: 31824187}
   m_Father: {fileID: 1083350552}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Seamount.unity
+++ b/Assets/Scenes/Seamount.unity
@@ -12365,6 +12365,7 @@ Transform:
   - {fileID: 1630570096}
   - {fileID: 388159188}
   - {fileID: 1915398901}
+  - {fileID: 1358484048}
   - {fileID: 1593325169}
   m_Father: {fileID: 454963240}
   m_RootOrder: 2
@@ -13166,7 +13167,7 @@ MonoBehaviour:
   model:
     virtualCamera: {fileID: 1085143582}
     player: {fileID: 1745679939}
-    spawnPoint: {fileID: 0}
+    spawnPoint: {fileID: 1358484048}
     jumpModifier: 0.9
     jumpDeceleration: 0
 --- !u!4 &1149256566
@@ -14565,6 +14566,37 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1358484047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1358484048}
+  m_Layer: 0
+  m_Name: SpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1358484048
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1358484047}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.39, y: -0.49, z: 0.3017578}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1083350552}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1380053323
 GameObject:
   m_ObjectHideFlags: 0
@@ -17366,7 +17398,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1083350552}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &1593325170
 SpriteRenderer:

--- a/Assets/Scenes/Seamount.unity
+++ b/Assets/Scenes/Seamount.unity
@@ -587,6 +587,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1577774018119691272, guid: f158aa2be3df6489185ef721f6fd79c1,
         type: 3}
+      propertyPath: m_FlipX
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1577774018119691272, guid: f158aa2be3df6489185ef721f6fd79c1,
+        type: 3}
       propertyPath: m_Size.x
       value: 1.28
       objectReference: {fileID: 0}

--- a/Assets/Scripts/Gameplay/PlayerAte.cs
+++ b/Assets/Scripts/Gameplay/PlayerAte.cs
@@ -14,7 +14,7 @@ namespace Platformer.Gameplay
         public EnemyController enemy;
         readonly PlayerController player = Simulation.GetModel<PlatformerModel>().player;
 
-        public Vector3 playerScaleChange = new(0.05f, 0.05f, 0.0f);
+        public Vector3 playerScaleChange = new(0.1f, 0.1f, 0.0f);
 
         public override void Execute()
         {

--- a/Assets/Scripts/Gameplay/PlayerEnemyCollision.cs
+++ b/Assets/Scripts/Gameplay/PlayerEnemyCollision.cs
@@ -1,4 +1,3 @@
-using Platformer.Core;
 using Platformer.Mechanics;
 using UnityEngine;
 using static Platformer.Core.Simulation;
@@ -9,22 +8,20 @@ namespace Platformer.Gameplay
     /// <summary>
     /// Fired when a Player collides with an Enemy.
     /// </summary>
-    /// <typeparam name="EnemyCollision"></typeparam>
-    public class PlayerEnemyCollision : Simulation.Event<PlayerEnemyCollision>
+    /// <typeparam name="PlayerEnemyCollision"></typeparam>
+    public class PlayerEnemyCollision : Event<PlayerEnemyCollision>
     {
         public EnemyController enemy;
         public PlayerController player;
 
         public override void Execute()
         {
-            // True if the player is touching the enemy from the x or y direction
             bool isCollisionY = player.Bounds.center.y >= enemy.Bounds.max.y || player.Bounds.center.y <= enemy.Bounds.max.y;
             bool isCollisionX = player.Bounds.center.x >= enemy.Bounds.max.x || player.Bounds.center.x <= enemy.Bounds.max.x;
 
             bool isCollision = isCollisionX || isCollisionY;
 
-            //is set to true if the player is the up to the size we want them to be to eat the enemy
-            bool canEatEnemy = enemy.deathPoint <= player.GetComponent<SpriteRenderer>().transform.localScale.x;
+            bool canEatEnemy = player.GetComponent<SpriteRenderer>().transform.localScale.x >= enemy.transform.localScale.x;
 
             if (!isCollision)
             {

--- a/Assets/Scripts/Mechanics/EnemyController.cs
+++ b/Assets/Scripts/Mechanics/EnemyController.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using Platformer.Gameplay;
+﻿using Platformer.Gameplay;
 using UnityEngine;
 using static Platformer.Core.Simulation;
 
@@ -22,12 +20,6 @@ namespace Platformer.Mechanics
         SpriteRenderer spriteRenderer;
 
         public Bounds Bounds => _collider.bounds;
-        //minium size needed to eat the enemy
-        public float deathPoint = 1f;
-
-        //tools for setting an enemys weak point
-        public bool xDeath;
-        public bool yDeath;
 
         void Awake()
         {
@@ -52,7 +44,7 @@ namespace Platformer.Mechanics
         {
             if (path != null)
             {
-                if (mover == null) mover = path.CreateMover(control.maxSpeed * 0.5f);
+                mover ??= path.CreateMover(control.maxSpeed * 0.5f);
                 control.move.x = Mathf.Clamp(mover.Position.x - transform.position.x, -1, 1);
                 control.move.y = Mathf.Clamp(mover.Position.y - transform.position.y, -1, 1);
             }

--- a/Assets/Scripts/Mechanics/EnemyController.cs
+++ b/Assets/Scripts/Mechanics/EnemyController.cs
@@ -1,4 +1,6 @@
-﻿using Platformer.Gameplay;
+﻿using Platformer.Core;
+using Platformer.Gameplay;
+using Platformer.Model;
 using UnityEngine;
 using static Platformer.Core.Simulation;
 
@@ -18,6 +20,8 @@ namespace Platformer.Mechanics
         internal Collider2D _collider;
         internal AudioSource _audio;
         SpriteRenderer spriteRenderer;
+
+        readonly PlatformerModel model = Simulation.GetModel<PlatformerModel>();
 
         public Bounds Bounds => _collider.bounds;
 
@@ -47,6 +51,23 @@ namespace Platformer.Mechanics
                 mover ??= path.CreateMover(control.maxSpeed * 0.5f);
                 control.move.x = Mathf.Clamp(mover.Position.x - transform.position.x, -1, 1);
                 control.move.y = Mathf.Clamp(mover.Position.y - transform.position.y, -1, 1);
+            }
+
+            ToggleDangerShader();
+        }
+
+        void ToggleDangerShader()
+        {
+            bool isDangerous = spriteRenderer.transform.localScale.x > model.player.GetComponent<SpriteRenderer>().transform.localScale.x;
+
+            Color transparent = new(1, 1, 1, 1);
+
+            if (isDangerous)
+            {
+                spriteRenderer.material.SetColor("_Color", Color.red);
+            } else if (spriteRenderer.material.color != transparent)
+            {
+                spriteRenderer.material.SetColor("_Color", transparent);
             }
         }
 

--- a/Assets/Scripts/Mechanics/KinematicObject.cs
+++ b/Assets/Scripts/Mechanics/KinematicObject.cs
@@ -65,6 +65,11 @@ namespace Platformer.Mechanics
         /// <param name="position"></param>
         public void Teleport(Vector3 position)
         {
+            if (body == null)
+            {
+                body = GetComponent<Rigidbody2D>();
+            }
+
             body.position = position;
             velocity *= 0;
             body.velocity *= 0;


### PR DESCRIPTION
These changes add the following:
- Whether a player can defeat an enemy depends on its size (horizontal scaling) relative to the player's. If the player is as big or bigger than the enemy, they win; if the enemy is bigger, it wins. Level designers can simply scale up an enemy to make it harder.
- Player respawning is "fixed" (minus the animations) in Seamount.
- A large crab sits at the beginning of the level. You have to eat ALL the fish in front of it to get big enough to defeat the large crab.
- Enemies too hard for the player to defeat are now RED. The shader will automatically update to normal colors once you get big enough. (Pay attention to this with the large crab.)

I'm currently targeting another PR of mine that's in review but will target main once that's merged.