### PR TITLE
Slowly zoom out camera as player sprite gets bigger.

### DIFF
--- a/Assets/Scripts/Gameplay/PlayerAte.cs
+++ b/Assets/Scripts/Gameplay/PlayerAte.cs
@@ -33,8 +33,11 @@ namespace Platformer.Gameplay
             // Scale up the player sprite after eating.
             player.GetComponent<SpriteRenderer>().transform.localScale += adjustedPlayerScaleChange;
 
+            View.ZoomOut.IncrementalZoomOut();
+
             // Increment the score after eating.
             ScoreController.UpdateScore(preyLevel);
         }
+
     }
 }

--- a/Assets/Scripts/View/ZoomOut.cs
+++ b/Assets/Scripts/View/ZoomOut.cs
@@ -9,7 +9,7 @@ namespace Platformer.View
         public PlatformerModel model = Simulation.GetModel<PlatformerModel>();
         private static float TargetOrthoSize = 3.5f;
         private static readonly float MinOrthoSize = 3.5f, MaxOrthoSize = 5.0f;
-        private float Speed = 0.01f;
+        private float Speed = 0.03f;
 
         void Start()
 	    {

--- a/Assets/Scripts/View/ZoomOut.cs
+++ b/Assets/Scripts/View/ZoomOut.cs
@@ -1,0 +1,50 @@
+﻿using UnityEngine;
+using Platformer.Core;
+using Platformer.Model;
+
+namespace Platformer.View
+{
+    public class ZoomOut : MonoBehaviour
+    {
+        public PlatformerModel model = Simulation.GetModel<PlatformerModel>();
+        private static float TargetOrthoSize = 3.5f;
+        private float speed = 0.03f;
+
+        void Start()
+	    {
+            TargetOrthoSize = model.virtualCamera.m_Lens.OrthographicSize;
+        }
+
+	    void Update()
+	    {
+            // Zoom out more quickly as player gets bigger.
+            if (model.player.transform.localScale.x > 3)
+            {
+                speed = 0.05f;
+            }
+            else if (model.player.transform.localScale.x > 4)
+            {
+                speed = 0.08f;
+            }
+            else if (model.player.transform.localScale.x > 5)
+            {
+                speed = 0.1f;
+            }
+            else if (model.player.transform.localScale.x > 6)
+            {
+                speed = 0.2f;
+            }
+
+            // Zoom out by no more than speed/second per frame until reaching target.
+            model.virtualCamera.m_Lens.OrthographicSize = Mathf.MoveTowards(model.virtualCamera.m_Lens.OrthographicSize, TargetOrthoSize, speed * Time.deltaTime);
+        }
+
+        // Zoom the camera out as the player gets bigger.
+        public static void IncrementalZoomOut()
+        {
+            float adjustedZoomChange = 0.1f;
+            TargetOrthoSize += adjustedZoomChange;
+        }
+    }
+}
+

--- a/Assets/Scripts/View/ZoomOut.cs
+++ b/Assets/Scripts/View/ZoomOut.cs
@@ -8,7 +8,8 @@ namespace Platformer.View
     {
         public PlatformerModel model = Simulation.GetModel<PlatformerModel>();
         private static float TargetOrthoSize = 3.5f;
-        private float speed = 0.03f;
+        private static readonly float MinOrthoSize = 3.5f, MaxOrthoSize = 5.0f;
+        private float Speed = 0.01f;
 
         void Start()
 	    {
@@ -17,26 +18,19 @@ namespace Platformer.View
 
 	    void Update()
 	    {
-            // Zoom out more quickly as player gets bigger.
-            if (model.player.transform.localScale.x > 3)
+            // Increase speed of zoom out as player grows.
+            switch (model.player.transform.localScale.x)
             {
-                speed = 0.05f;
-            }
-            else if (model.player.transform.localScale.x > 4)
-            {
-                speed = 0.08f;
-            }
-            else if (model.player.transform.localScale.x > 5)
-            {
-                speed = 0.1f;
-            }
-            else if (model.player.transform.localScale.x > 6)
-            {
-                speed = 0.2f;
+                case 2:
+                case 3:
+                case 4:
+                case 5:
+                    Speed *= model.player.transform.localScale.x;
+                    break;
             }
 
             // Zoom out by no more than speed/second per frame until reaching target.
-            model.virtualCamera.m_Lens.OrthographicSize = Mathf.MoveTowards(model.virtualCamera.m_Lens.OrthographicSize, TargetOrthoSize, speed * Time.deltaTime);
+            model.virtualCamera.m_Lens.OrthographicSize = Mathf.MoveTowards(model.virtualCamera.m_Lens.OrthographicSize, TargetOrthoSize, Speed * Time.deltaTime);
         }
 
         // Zoom the camera out as the player gets bigger.
@@ -44,6 +38,7 @@ namespace Platformer.View
         {
             float adjustedZoomChange = 0.1f;
             TargetOrthoSize += adjustedZoomChange;
+            TargetOrthoSize = Mathf.Clamp(TargetOrthoSize, MinOrthoSize, MaxOrthoSize);
         }
     }
 }

--- a/Assets/Scripts/View/ZoomOut.cs.meta
+++ b/Assets/Scripts/View/ZoomOut.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5fd211af3ab68417f83ccee64258ad94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The virtual camera will very slowly zoom out as the player grows in size, to a max orthographic lens size that doesn't interfere much with level boundaries. Zooming out more than the max becomes a problem in the close quarters at the end of Seamount.