### PR TITLE
Lights and FX adjustments

### DIFF
--- a/Assets/Scripts/Gameplay/StartVictoryScene.cs
+++ b/Assets/Scripts/Gameplay/StartVictoryScene.cs
@@ -5,14 +5,14 @@ using System.Collections;
 public class StartVictoryScene : MonoBehaviour
 {
     private readonly string VictorySceneName = "Victory";
-    private int SecondsToDelay = 3;
+    private readonly float SecondsToDelay = 3.5f;
 
     public void StartAfterDelay()
     {
         StartCoroutine(LoadVictorySceneAfterDelay(SecondsToDelay));
     }
 
-    private IEnumerator LoadVictorySceneAfterDelay(int seconds)
+    private IEnumerator LoadVictorySceneAfterDelay(float seconds)
     {
         // Wait a few seconds before loading the victory scene
         // so victory animations can complete.

--- a/Assets/Scripts/Gameplay/StartVictoryScene.cs
+++ b/Assets/Scripts/Gameplay/StartVictoryScene.cs
@@ -5,7 +5,7 @@ using System.Collections;
 public class StartVictoryScene : MonoBehaviour
 {
     private readonly string VictorySceneName = "Victory";
-    private readonly float SecondsToDelay = 3.5f;
+    private readonly float SecondsToDelay = 5;
 
     public void StartAfterDelay()
     {

--- a/Assets/Scripts/Mechanics/EnemyController.cs
+++ b/Assets/Scripts/Mechanics/EnemyController.cs
@@ -69,31 +69,6 @@ namespace Platformer.Mechanics
                 spriteRenderer.material.SetColor("_Color", transparent);
                 gameObject.GetComponent<Light2D>().color = Color.white;
             }
-
-            if (IsBoss() && IsDangerous())
-            {
-                spriteRenderer.material.SetColor("_Color", transparent);
-                gameObject.GetComponent<Light2D>().intensity = 2f;
-                return;
-            }
-            else if (IsBoss())
-            {
-                gameObject.GetComponent<Light2D>().intensity = 0.8f;
-                return;
-            }
-
-            if (IsDangerous())
-            {
-                gameObject.GetComponent<Light2D>().intensity = 2;
-                gameObject.GetComponent<Light2D>().pointLightInnerRadius = 0.25f;
-                gameObject.GetComponent<Light2D>().pointLightOuterRadius = 1;
-            }
-            else
-            {
-                gameObject.GetComponent<Light2D>().intensity = 0.1f;
-                gameObject.GetComponent<Light2D>().pointLightInnerRadius = 0.25f;
-                gameObject.GetComponent<Light2D>().pointLightOuterRadius = 2;
-            }
         }
 
         public bool IsDangerous()
@@ -102,11 +77,6 @@ namespace Platformer.Mechanics
             float playerScale = model.player.GetComponent<SpriteRenderer>().transform.localScale.x;
 
             return enemyScale > playerScale;
-        }
-
-        public bool IsBoss()
-        {
-            return gameObject.transform.localScale.x >= 7;
         }
     }
 }

--- a/Assets/Scripts/Mechanics/EnemyController.cs
+++ b/Assets/Scripts/Mechanics/EnemyController.cs
@@ -57,23 +57,43 @@ namespace Platformer.Mechanics
 
         void ToggleDangerShader()
         {
+            Color transparent = new(1, 1, 1, 1);
+
             if (IsDangerous())
             {
-                gameObject.GetComponent<Light2D>().intensity = 3;
+                spriteRenderer.material.SetColor("_Color", Color.red);
+                gameObject.GetComponent<Light2D>().color = Color.red;
+            }
+            else
+            {
+                spriteRenderer.material.SetColor("_Color", transparent);
+                gameObject.GetComponent<Light2D>().color = Color.white;
+            }
+
+            if (IsBoss() && IsDangerous())
+            {
+                spriteRenderer.material.SetColor("_Color", transparent);
+                gameObject.GetComponent<Light2D>().intensity = 2f;
+                return;
+            }
+            else if (IsBoss())
+            {
+                gameObject.GetComponent<Light2D>().intensity = 0.8f;
+                return;
+            }
+
+            if (IsDangerous())
+            {
+                gameObject.GetComponent<Light2D>().intensity = 2;
                 gameObject.GetComponent<Light2D>().pointLightInnerRadius = 0.25f;
                 gameObject.GetComponent<Light2D>().pointLightOuterRadius = 1;
-                gameObject.GetComponent<Light2D>().color = Color.red;
-            } else
+            }
+            else
             {
                 gameObject.GetComponent<Light2D>().intensity = 0.1f;
                 gameObject.GetComponent<Light2D>().pointLightInnerRadius = 0.25f;
                 gameObject.GetComponent<Light2D>().pointLightOuterRadius = 2;
-                gameObject.GetComponent<Light2D>().color = Color.white;
             }
-            //} else if (spriteRenderer.material.color != transparent)
-            //{
-            //    spriteRenderer.material.SetColor("_Color", transparent);
-            //}
         }
 
         public bool IsDangerous()
@@ -82,6 +102,11 @@ namespace Platformer.Mechanics
             float playerScale = model.player.GetComponent<SpriteRenderer>().transform.localScale.x;
 
             return enemyScale > playerScale;
+        }
+
+        public bool IsBoss()
+        {
+            return gameObject.transform.localScale.x >= 7;
         }
     }
 }

--- a/Assets/Scripts/Mechanics/EnemyController.cs
+++ b/Assets/Scripts/Mechanics/EnemyController.cs
@@ -2,6 +2,7 @@
 using Platformer.Gameplay;
 using Platformer.Model;
 using UnityEngine;
+using UnityEngine.Rendering.Universal;
 using static Platformer.Core.Simulation;
 
 namespace Platformer.Mechanics
@@ -56,15 +57,23 @@ namespace Platformer.Mechanics
 
         void ToggleDangerShader()
         {
-            Color transparent = new(1, 1, 1, 1);
-
             if (IsDangerous())
             {
-                spriteRenderer.material.SetColor("_Color", Color.red);
-            } else if (spriteRenderer.material.color != transparent)
+                gameObject.GetComponent<Light2D>().intensity = 3;
+                gameObject.GetComponent<Light2D>().pointLightInnerRadius = 0.25f;
+                gameObject.GetComponent<Light2D>().pointLightOuterRadius = 1;
+                gameObject.GetComponent<Light2D>().color = Color.red;
+            } else
             {
-                spriteRenderer.material.SetColor("_Color", transparent);
+                gameObject.GetComponent<Light2D>().intensity = 0.1f;
+                gameObject.GetComponent<Light2D>().pointLightInnerRadius = 0.25f;
+                gameObject.GetComponent<Light2D>().pointLightOuterRadius = 2;
+                gameObject.GetComponent<Light2D>().color = Color.white;
             }
+            //} else if (spriteRenderer.material.color != transparent)
+            //{
+            //    spriteRenderer.material.SetColor("_Color", transparent);
+            //}
         }
 
         public bool IsDangerous()

--- a/Assets/Scripts/Mechanics/VictoryZone.cs
+++ b/Assets/Scripts/Mechanics/VictoryZone.cs
@@ -12,7 +12,7 @@ namespace Platformer.Mechanics
     {
         public AudioClip victoryAudio;
         private bool playerEnteredVictoryZone = false;
-        private readonly float fadeOutSpeed = 100;
+        private readonly float fadeOutSpeed = 25;
 
         private void Update()
         {

--- a/Assets/Scripts/Mechanics/VictoryZone.cs
+++ b/Assets/Scripts/Mechanics/VictoryZone.cs
@@ -12,7 +12,7 @@ namespace Platformer.Mechanics
     {
         public AudioClip victoryAudio;
         private bool playerEnteredVictoryZone = false;
-        private readonly float fadeOutSpeed = 25;
+        private readonly float fadeOutSpeed = 50;
 
         private void Update()
         {

--- a/Assets/Scripts/Mechanics/VictoryZone.cs
+++ b/Assets/Scripts/Mechanics/VictoryZone.cs
@@ -1,5 +1,6 @@
 using Platformer.Gameplay;
 using UnityEngine;
+using UnityEngine.Rendering.Universal;
 using static Platformer.Core.Simulation;
 
 namespace Platformer.Mechanics
@@ -10,6 +11,18 @@ namespace Platformer.Mechanics
     public class VictoryZone : MonoBehaviour
     {
         public AudioClip victoryAudio;
+        private bool playerEnteredVictoryZone = false;
+        private readonly float fadeOutSpeed = 100;
+
+        private void Update()
+        {
+            if (!playerEnteredVictoryZone)
+            {
+                return;
+            }
+
+            FadeToColor();
+        }
 
         void OnTriggerEnter2D(Collider2D collider)
         {
@@ -18,7 +31,28 @@ namespace Platformer.Mechanics
             {
                 var ev = Schedule<PlayerEnteredVictoryZone>();
                 ev.victoryZone = this;
+                playerEnteredVictoryZone = true;
             }
         }
+
+        void FadeToColor()
+        {
+            GameObject totem = GameObject.Find("Totem");
+            if (!totem)
+            {
+                return;
+            }
+
+            Light2D totemLight = totem.GetComponentInChildren<Light2D>();
+            if (!totemLight)
+            {
+                return;
+            }
+
+            totemLight.intensity = Mathf.MoveTowards(totemLight.intensity, float.MaxValue, fadeOutSpeed * Time.deltaTime);
+            totemLight.pointLightOuterRadius = Mathf.MoveTowards(totemLight.pointLightOuterRadius, float.MaxValue, fadeOutSpeed * Time.deltaTime);
+            totemLight.pointLightInnerRadius = Mathf.MoveTowards(totemLight.pointLightInnerRadius, float.MaxValue, fadeOutSpeed * Time.deltaTime); ;
+        }
+
     }
 }


### PR DESCRIPTION
- Enemies glow red instead of white now when they're dangerous.
- The totem at the end starts glowing intensely for 5 seconds before switching to the Victory scene. This goes well with the new sound FX.